### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/release-docker-gke-demo.yml
+++ b/.github/workflows/release-docker-gke-demo.yml
@@ -12,7 +12,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Build and push to Docker Hub
-      uses: elgohr/Publish-Docker-Github-Action@2.12
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: ilyalesikov/gke-demo
         username: ${{ secrets.DOCKER_USERNAME }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore